### PR TITLE
feat: extend trust relationships with additional policies

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -9,6 +9,19 @@ locals {
     },
   )
 
+  default_assume_role_policy = [
+    {
+      Action = [
+        "sts:AssumeRole"
+      ]
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+      Effect = "Allow"
+      Sid    = ""
+    },
+  ]
+
   logging_policy = [
     {
       Action = [
@@ -32,6 +45,8 @@ locals {
       Effect = "Allow"
     }
   ]
+
+  assume_role_policies = concat(local.default_assume_role_policy, var.additional_assume_role_policies)
 
   policies = var.dead_letter_target == null ? concat(local.logging_policy, var.policies) : concat(local.logging_policy, local.dlq_policy, var.policies)
 }

--- a/main.tf
+++ b/main.tf
@@ -4,16 +4,7 @@ resource "aws_iam_role" "lambda_role" {
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
+  "Statement": ${jsonencode(local.assume_role_policies)}
 }
 EOF
 

--- a/variables.tf
+++ b/variables.tf
@@ -85,6 +85,19 @@ variable "vpc_security_groups" {
   default     = null
 }
 
+variable "additional_assume_role_policies" {
+  description = "List of objects defining additional non-Lambda IAM trust relationship statements"
+  type = list(object({
+    Action = list(string)
+    Principal = object({
+      Service = string
+    })
+    Effect = string
+  }))
+  default = []
+}
+
+
 variable "policies" {
   description = "List of objects defining IAM policy statements"
   type = list(object({


### PR DESCRIPTION
* Adds a new variable `assume_role_policies` to extend the default trust relationship for Lambda's IAM role by adding additional policies