### PR TITLE
fix: define iam role dependency to help with fresh deployment edge case

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -18,7 +18,6 @@ locals {
         Service = "lambda.amazonaws.com"
       }
       Effect = "Allow"
-      Sid    = ""
     },
   ]
 

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,11 @@ resource "aws_lambda_function" "lambda" {
   layers                         = var.layers
   description                    = var.description
 
-  depends_on = [aws_cloudwatch_log_group.lambda]
+  depends_on = [
+    aws_cloudwatch_log_group.lambda,
+    aws_iam_role_policy_attachment.lambda_attachment_vpc_exec,
+    aws_iam_role_policy_attachment.lambda_policy_attachment
+  ]
 
   environment {
     variables = local.environment


### PR DESCRIPTION
## What?
- "Trying" to resolve lambda unable to invoke due to inability to assume role on first deploy
   - this also linked to the deployment of lambda issues via codedeploy on brand new stacks (atlantis-deployer)

![image](https://user-images.githubusercontent.com/4026343/92104834-d1b1d480-edd9-11ea-8c44-816b8d504c4a.png)


Have seen improvements on my fresh stacks for personalised rail with this change. Though..when manually trying to invoke the lambda i still have errors. Need to wait for like 5-10 mins before we can invoke lambda's manually after a fresh deployment. Forums also report similar behaviour..