### PR TITLE
feat(iam): remove AWSLambdaVPCAccessExecutionRole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .terraform
 node_modules
+provider.tf

--- a/locals.tf
+++ b/locals.tf
@@ -33,6 +33,20 @@ locals {
     }
   ]
 
+  vpc_access_policy = [
+    {
+      Effect = "Allow"
+      Action = [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface"
+      ],
+      Resource = [
+        "*"
+      ]
+    }
+  ]
+
   dlq_policy = [
     {
       Action = [
@@ -47,5 +61,8 @@ locals {
 
   assume_role_policies = concat(local.default_assume_role_policy, var.additional_assume_role_policies)
 
-  policies = var.dead_letter_target == null ? concat(local.logging_policy, var.policies) : concat(local.logging_policy, local.dlq_policy, var.policies)
+  policies_with_dlq    = var.vpc_subnets == null ? concat(local.logging_policy, local.dlq_policy, var.policies) : concat(local.logging_policy, local.dlq_policy, local.vpc_access_policy, var.policies)
+  policies_without_dlq = var.vpc_subnets == null ? concat(local.logging_policy, var.policies) : concat(local.logging_policy, local.vpc_access_policy, var.policies)
+
+  policies = var.dead_letter_target == null ? local.policies_without_dlq : local.policies_with_dlq
 }

--- a/main.tf
+++ b/main.tf
@@ -28,11 +28,6 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   policy_arn = aws_iam_policy.lambda_policy.arn
 }
 
-resource "aws_iam_role_policy_attachment" "lambda_attachment_vpc_exec" {
-  role       = aws_iam_role.lambda_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
-}
-
 resource "aws_cloudwatch_log_group" "lambda" {
   name              = "/aws/lambda/${var.name}"
   retention_in_days = var.log_retention
@@ -56,7 +51,6 @@ resource "aws_lambda_function" "lambda" {
 
   depends_on = [
     aws_cloudwatch_log_group.lambda,
-    aws_iam_role_policy_attachment.lambda_attachment_vpc_exec,
     aws_iam_role_policy_attachment.lambda_policy_attachment
   ]
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,24 @@
 output "arn" {
   description = "ARN for the lambda function"
-  value = aws_lambda_function.lambda.arn
+  value       = aws_lambda_function.lambda.arn
 }
 
 output "name" {
   description = "The lambda function name"
-  value = var.name
+  value       = var.name
 }
 
 output "alias" {
   description = "Name of the lambda function alias"
-  value = var.alias
+  value       = var.alias
 }
 
 output "version" {
   description = "Current version of the lambda function"
-  value = aws_lambda_function.lambda.version
+  value       = aws_lambda_function.lambda.version
 }
 
 output "role" {
   description = "Name of the lambda role"
-  value = aws_iam_role.lambda_role.name
+  value       = aws_iam_role.lambda_role.name
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "index.js",
   "scripts": {
     "dependabump": "ncu -u && rm -rf package-lock.json node_modules | true && npm i",
-    "release": "semantic-release --debug"
+    "release": "semantic-release --debug",
+    "pretest": "echo 'provider \"aws\" { region = \"eu-central-1\" }' > provider.tf && terraform fmt -write=true",
+    "test": "terraform init && terraform validate",
+    "posttest": "rm provider.tf"
   },
   "repository": {
     "type": "git",
@@ -71,6 +74,7 @@
   },
   "husky": {
     "hooks": {
+      "pre-commit": "npm test",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
   },

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.11"
 
   required_providers {
-    aws      = "~> 2.0"
+    aws = "~> 2.0"
   }
 }


### PR DESCRIPTION
The AWSLambdaVPCAccessExecutionRole doesn't just provide vpc access permissions, it additionaly
grants the lambda permission to create log groups. This PR removes that service role attachments and
just adds the ec2 permissions directly to the policy if vpc config is passed.