### PR TITLE
feat: add support for lambda insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ No modules.
 | [aws_cloudwatch_log_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_policy.lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.lambda_insights_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_alias.alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) | resource |
 | [aws_lambda_alias.alias_instant](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_alias) | resource |
@@ -105,6 +106,7 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | Description of what the Lambda Function does | `string` | `null` | no |
 | <a name="input_environment_vars"></a> [environment\_vars](#input\_environment\_vars) | n/a | `map(string)` | `{}` | no |
 | <a name="input_handler"></a> [handler](#input\_handler) | Path to the lambda handler | `string` | n/a | yes |
+| <a name="input_insights_enabled"></a> [insights\_enabled](#input\_insights\_enabled) | Turn on Lambda insights for the Lambda (limited regions only) | `bool` | `false` | no |
 | <a name="input_instant_alias_update"></a> [instant\_alias\_update](#input\_instant\_alias\_update) | Whether to immediately point the alias at the latest version | `bool` | `false` | no |
 | <a name="input_lambda_concurrency"></a> [lambda\_concurrency](#input\_lambda\_concurrency) | Limit concurrent executions of the lambda fn | `number` | `null` | no |
 | <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | Runtime to invoke the lambda with | `string` | n/a | yes |

--- a/locals.tf
+++ b/locals.tf
@@ -67,6 +67,20 @@ locals {
 
   policies = var.dead_letter_target == null ? local.policies_without_dlq : local.policies_with_dlq
 
-
   lambda_role_name = var.custom_role_name == "" ? "${var.name}-lambda-${var.aws_region}" : var.custom_role_name
+
+  insights_layer_region_map = {
+    "x86-64" = {
+      "us-east-1"      = "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension:16"
+      "eu-central-1"   = "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension:16"
+      "ap-northeast-1" = "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:23"
+    }
+    arm64 = {
+      "us-east-1"      = "arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension-Arm64:1"
+      "eu-central-1"   = "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension-Arm64:1"
+      "ap-northeast-1" = "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension-Arm64:1"
+    }
+  }
+
+  layers = concat(var.layers, var.insights_enabled ? [local.insights_layer_region_map[var.architecture][var.aws_region]] : [])
 }

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,12 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   policy_arn = aws_iam_policy.lambda_policy.arn
 }
 
+resource "aws_iam_role_policy_attachment" "lambda_insights_policy_attachment" {
+  count      = var.insights_enabled ? 1 : 0
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy"
+}
+
 resource "aws_cloudwatch_log_group" "lambda" {
   name              = "/aws/lambda/${var.name}"
   retention_in_days = var.log_retention
@@ -47,12 +53,13 @@ resource "aws_lambda_function" "lambda" {
   s3_key                         = var.s3_key
   reserved_concurrent_executions = var.lambda_concurrency
   publish                        = var.publish
-  layers                         = var.layers
+  layers                         = local.layers
   description                    = var.description
 
   depends_on = [
     aws_cloudwatch_log_group.lambda,
-    aws_iam_role_policy_attachment.lambda_policy_attachment
+    aws_iam_role_policy_attachment.lambda_policy_attachment,
+    aws_iam_role_policy_attachment.lambda_insights_policy_attachment
   ]
 
   environment {

--- a/variables.tf
+++ b/variables.tf
@@ -165,3 +165,9 @@ variable "custom_role_name" {
   type        = string
   default     = ""
 }
+
+variable "insights_enabled" {
+  description = "Turn on Lambda insights for the Lambda (limited regions only)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
* Adds support for enabling Lambda insights by attaching the appropriate lambda layer to the function.
* Only supports the following regions so far:
	* `eu-central-1`
	* `us-east-1`
	* `ap-northeast-1`

Ref: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-Getting-Started-cli.html