### PR TITLE
fix: fix race condition on function name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "invoke_arn" {
 
 output "name" {
   description = "The lambda function name"
-  value       = var.name
+  value       = aws_lambda_function.lambda.function_name
 }
 
 output "alias" {


### PR DESCRIPTION
Sets the `name` output to the `function_name` property of the lambda itself to ensure that it isn't populated until the lambda has been created.